### PR TITLE
fix(api): Access to Redoc documentation on development

### DIFF
--- a/api/.env-dist
+++ b/api/.env-dist
@@ -10,6 +10,7 @@ POSTGRES_DATA=/var/lib/postgresql/data/pgdata
 NGINX_ENVSUBST_OUTPUT_DIR=/etc/nginx
 
 # api-layer
+DJANGO_SECRET_KEY=somesupersecretkey
 DOMAIN_NAME=voron.lan
 PRODUCTION=1
 

--- a/api/README.md
+++ b/api/README.md
@@ -132,8 +132,15 @@ python manage.py test api.tests.AuthTestCase.test_can_login_customer_account
 
 ## 🔍 Usage
 
-You may find an [OpenAPI](https://www.openapis.org/) specification at the `/docs` endpoint.
-This can then be important in the REST client of your choice, we recommend:
+### Access docs
+
+To access the `/docs` endpoint of the API in your browser, you must run the API like so:
+```bash
+python manage.py runserver --insecure
+```
+
+You may then find an [OpenAPI](https://www.openapis.org/) specification at the `http://localhost:8000/docs` endpoint.
+This can then be imported in the REST client of your choice, we recommend:
 - [Postman](https://www.postman.com/) -- industry leader, full of features, and great for development within a team.
 - [Insomnia](https://insomnia.rest/) -- works offline, comfy UI, super easy to work with.
 - [HTTPie](https://httpie.io/docs/cli) -- works in the Terminal, but currently cannot import OpenAPI specs.

--- a/api/core/settings.py
+++ b/api/core/settings.py
@@ -137,7 +137,7 @@ if os.environ.get('PRODUCTION', '0') == '1':
             'NAME': os.environ.get('POSTGRES_DB'),
             'USER': os.environ.get('POSTGRES_USER'),
             'PASSWORD': os.environ.get('POSTGRES_PASSWORD'),
-            'HOST': 'db',
+            'HOST': os.environ.get('POSTGRES_HOST'),
             'PORT': os.environ.get('POSTGRES_PORT'),
         }
     }
@@ -148,7 +148,7 @@ elif os.environ.get('TEST') and os.environ.get('TEST')  == '1':
     DATABASES = {
         'default': {
             'ENGINE': 'django.db.backends.postgresql',
-            'NAME': 'core',
+            'NAME': 'voron',
             'USER': os.environ.get('USER'),
             'PASSWORD': 'postgres',
             'HOST': 'localhost',

--- a/api/core/urls.py
+++ b/api/core/urls.py
@@ -4,8 +4,8 @@ from rest_framework import routers
 from rest_framework import permissions
 from rest_framework.urls import path
 
+from django.conf.urls.static import static
 from django.urls import re_path
-from django.conf.urls import include
 
 from drf_yasg.views import get_schema_view
 from drf_yasg import openapi
@@ -19,7 +19,7 @@ SchemaView = get_schema_view(
       title="voron API",
       default_version='1.0',
       description="API storing and managing notes, users, and stuff",
-      terms_of_service="https://voron.djnn.sh/terms", # FIXME(clara): add this page in front-end
+      terms_of_service="https://github.com/vrn-sh/erp/blob/current/LICENSE",
       contact=openapi.Contact(email="voron@djnn.sh"),
       license=openapi.License(name="MIT License"),
    ),
@@ -38,7 +38,5 @@ urlpatterns = [
     path('confirm', ConfirmAccountView.as_view()),
     path('reset', ResetPasswordView.as_view()),
     path('register', RegisterViewset.as_view({'post': 'create'})),
-    re_path(r'docs', SchemaView.with_ui('redoc', cache_timeout=0), name='schema-redoc'),
-    re_path(r'^auth/', include('trench.urls')),
-    re_path(r'^auth/', include('trench.urls.authtoken')),
+    re_path(r'^docs/$', SchemaView.with_ui('redoc', cache_timeout=0), name='schema-redoc'),
 ] + router.urls

--- a/api/scripts/nuke.sh
+++ b/api/scripts/nuke.sh
@@ -3,6 +3,6 @@
 echo "This script will destroy the database. Are you sure you want to delete this database ?"
 read -rp "Press [Enter] key to continue..."
 
-export DATABASE="core"
+export DATABASE="voron"
 sudo -u postgres psql -c "DROP DATABASE IF EXISTS ${DATABASE};"
 sudo -u postgres psql -c "DROP DATABASE IF EXISTS ${DATABASE}_test;"

--- a/api/scripts/setup.sh
+++ b/api/scripts/setup.sh
@@ -13,7 +13,7 @@ install_postgresql () {
 
     export POSTGRES_USER="${USER}"
     export POSTGRES_PASSWORD="postgres"
-    export POSTGRES_DB="core"
+    export POSTGRES_DB="voron"
 
     # Create the database
     echo "Creating database $POSTGRES_DB"


### PR DESCRIPTION
# Description
as specified in #65, documentation is auto-generated & accessible through `/docs` endpoint.
Support is now better described, and we fix some crashes on startup when setting up the app.

# Fixes

# Changes include

- BREAKING: adding missing `DJANGO_SECRET_KEY` env value, be sure to update your `.env` files
- better docs 
- yeah

# Breaking changes

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added @vrn-sh/members to the reviewers, or specific members of the team
- [x] I have added the needed labels
- [x] I have tested this code
- [x] I have added / updated tests (unit / functionals / end-to-end / ...)
- [x] I have updated the README and other relevant documents (guides...)

# Additional comments
Please have a look the [docs](./api/README.md) to know how to implement routes in front-end