### PR TITLE
fix(api): Upgrading auth-token management system

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -5,7 +5,12 @@ RUN apt-get update \
     && apt-get -y upgrade \
     && apt-get install -y --no-install-recommends \
     apt-utils \
-    postgresql-client
+    postgresql-client \
+    build-essential \
+    libssl-dev \
+    libffi-dev \
+    python3-dev \
+    python-dev
 
 WORKDIR /api
 

--- a/api/api/tests/__init__.py
+++ b/api/api/tests/__init__.py
@@ -1,4 +1,3 @@
-import warnings
 
 from django.test import TransactionTestCase
 from faker import Faker
@@ -52,11 +51,11 @@ class AuthTestCase(TransactionTestCase):
         client = APIClient()
         auth_token = login_as(self.manager.auth.email, random_user_password())
         client.credentials(HTTP_AUTHORIZATION=f'Token {auth_token}')
-        response = client.get('/logout')
-        self.assertEqual(response.status_code, 200) # type: ignore
+        response = client.post('/logout')
+        self.assertEqual(response.status_code, 204) # type: ignore
 
     def test_unknown_account(self) -> None:
-        """unknown account should get 404"""
+        """unknown account should get 400"""
 
         client = APIClient()
         response = client.post(
@@ -64,10 +63,10 @@ class AuthTestCase(TransactionTestCase):
                 format='json',
                 data={'email': 'email@email.com', 'password': '1234'}
                 )
-        self.assertEqual(response.status_code, 404) # type: ignore
+        self.assertEqual(response.status_code, 400) # type: ignore
 
     def test_wrong_password(self) -> None:
-        """wrong password should get 403"""
+        """wrong password should get 400"""
 
         client = APIClient()
         response = client.post(
@@ -75,7 +74,7 @@ class AuthTestCase(TransactionTestCase):
                 format='json',
                 data={'email': self.manager.auth.email, 'password': '1234'}
                 )
-        self.assertEqual(response.status_code, 403) # type: ignore
+        self.assertEqual(response.status_code, 400) # type: ignore
 
 
 class RegisterTestCase(TransactionTestCase):
@@ -124,8 +123,8 @@ class CRUDManagerTestCase(TransactionTestCase):
         self.client.credentials(HTTP_AUTHORIZATION=f'Token {self.auth_token}') # type: ignore
 
     def tearDown(self) -> None:
-        response = self.client.get('/logout')
-        self.assertEqual(response.status_code, 200)
+        response = self.client.post('/logout')
+        self.assertEqual(response.status_code, 204)
         self.manager.delete()
 
     def test_create_a_manager(self):
@@ -217,8 +216,8 @@ class CRUDManagerTestCase(TransactionTestCase):
         self.client.credentials(HTTP_AUTHORIZATION=f'Token {self.auth_token}') # type: ignore
 
     def tearDown(self) -> None:
-        response = self.client.get('/logout')
-        self.assertEqual(response.status_code, 200)
+        response = self.client.post('/logout')
+        self.assertEqual(response.status_code, 204)
         self.manager.delete()
 
     def test_create_a_manager(self):

--- a/api/api/tests/helpers.py
+++ b/api/api/tests/helpers.py
@@ -4,7 +4,7 @@ from datetime import date, datetime
 from typing import Any
 from faker import Faker
 
-from rest_framework.test import APIRequestFactory
+from rest_framework.test import APIClient, APIRequestFactory
 
 from api.models import *
 from api.models.mission import Mission, Recon
@@ -14,15 +14,14 @@ from api.views import LoginView
 def login_as(email: str, password: str) -> str:
     """login as specific user (email/password)"""
     login = LoginView.as_view()
-    fct = APIRequestFactory()
+    fct = APIClient()
     body = {
         'email': email,
         'password': password
     }
 
-    request = fct.post('/login', data=body, format='json')
-    response = login(request)
-    assert response.status_code == 201
+    response = fct.post('/login', data=body, format='json')
+    assert response.status_code == 200
     return response.data['token'] # type: ignore
 
 

--- a/api/api/views/viewsets/__init__.py
+++ b/api/api/views/viewsets/__init__.py
@@ -12,16 +12,17 @@ from typing import List
 
 from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
+
 from rest_framework import viewsets, permissions
-from rest_framework.authentication import TokenAuthentication
 from rest_framework.status import HTTP_400_BAD_REQUEST
 from rest_framework.views import Response
+
+from knox.auth import TokenAuthentication
+
 from api.backends import EmailBackend
 
 from api.serializers import ManagerSerializer, PentesterSerializer, AuthSerializer, TeamSerializer
-
 from api.models import USER_ROLES, Manager, Auth, Pentester, Team, get_user_model
-
 from api.permissions import IsManager, IsOwner, PostOnly, ReadOnly
 
 
@@ -44,10 +45,10 @@ class TeamViewset(viewsets.ModelViewSet): # pylint: disable=too-many-ancestors
             properties={
                 'name': openapi.Schema(type=openapi.TYPE_STRING,
                                        description="Team name"),
-                'members': openapi.Schema(type=openapi.TYPE_ARRAY, 
+                'members': openapi.Schema(type=openapi.TYPE_ARRAY,
                                           description="Array of id members",
                                           items=openapi.Items(type=openapi.TYPE_INTEGER),),
-                'leader': openapi.Schema(type=openapi.TYPE_INTEGER, 
+                'leader': openapi.Schema(type=openapi.TYPE_INTEGER,
                                          description="Id of the leader"),
             },
         ),
@@ -85,7 +86,7 @@ class TeamViewset(viewsets.ModelViewSet): # pylint: disable=too-many-ancestors
             properties={
                 'name': openapi.Schema(type=openapi.TYPE_STRING,
                                        description="Team name"),
-                'members': openapi.Schema(type=openapi.TYPE_ARRAY, 
+                'members': openapi.Schema(type=openapi.TYPE_ARRAY,
                                           description="Array of id members",
                                           items=openapi.Items(type=openapi.TYPE_INTEGER),),
             },
@@ -132,7 +133,7 @@ class PentesterViewset(viewsets.ModelViewSet): # pylint: disable=too-many-ancest
     """
 
     queryset = Pentester.objects.all()
-    permission_classes = [permissions.IsAuthenticated & IsManager | IsOwner]
+    permission_classes = [permissions.IsAuthenticated, IsManager | IsOwner]
     authentication_classes = [TokenAuthentication]
     serializer_class = PentesterSerializer
 

--- a/api/api/views/viewsets/mission.py
+++ b/api/api/views/viewsets/mission.py
@@ -4,7 +4,7 @@ from warnings import warn
 from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import viewsets, permissions
-from rest_framework.authentication import TokenAuthentication
+from knox.auth import TokenAuthentication
 from rest_framework.routers import Response
 from rest_framework.status import HTTP_201_CREATED, HTTP_400_BAD_REQUEST
 

--- a/api/api/views/viewsets/vulns.py
+++ b/api/api/views/viewsets/vulns.py
@@ -4,7 +4,7 @@ from warnings import warn
 from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import viewsets, permissions
-from rest_framework.authentication import TokenAuthentication
+from knox.auth import TokenAuthentication
 from rest_framework.status import HTTP_400_BAD_REQUEST, HTTP_404_NOT_FOUND
 from rest_framework.views import Response
 from api.models import Auth

--- a/api/core/settings.py
+++ b/api/core/settings.py
@@ -14,8 +14,16 @@ from pathlib import Path
 import string
 import os
 
+from datetime import timedelta
+
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
+
+
+REST_KNOX = {
+  'AUTH_TOKEN_CHARACTER_LENGTH': 128,
+  'TOKEN_TTL': timedelta(hours=12),
+}
 
 
 SWAGGER_SETTINGS = {
@@ -54,6 +62,7 @@ INSTALLED_APPS = [
     'drf_yasg',
     "phonenumber_field",
     "corsheaders",
+    "knox",
 ]
 
 MIDDLEWARE = [
@@ -205,7 +214,7 @@ REST_FRAMEWORK = {
         'rest_framework.permissions.AllowAny'
     ],
     'DEFAULT_AUTHENTICATION_CLASSES': [
-        'rest_framework.authentication.TokenAuthentication',
+        'knox.auth.TokenAuthentication',
     ],
     'DEFAULT_RENDERER_CLASSES': (
         'rest_framework.renderers.JSONRenderer',

--- a/api/core/urls.py
+++ b/api/core/urls.py
@@ -3,18 +3,16 @@
 from rest_framework import routers
 from rest_framework import permissions
 from rest_framework.urls import path
-
-from django.conf.urls.static import static
 from django.urls import re_path
 
 from drf_yasg.views import get_schema_view
 from drf_yasg import openapi
 
-from api.views import LoginView, LogoutView, PingView, ConfirmAccountView, ResetPasswordView
+from knox.views import LogoutView
+
+from api.views import LoginView, PingView, ConfirmAccountView, ResetPasswordView
 from api.views.viewsets import RegisterViewset, PentesterViewset, ManagerViewset, TeamViewset
-
 from api.views.viewsets.vulns import NotesViewset, VulnerabilityViewset, VulnTypeViewset
-
 from api.views.viewsets.mission import MissionViewset, NmapViewset, ReconViewset
 
 # SchemaView provides view for OpenAPI specifications (using Redoc template)
@@ -43,8 +41,8 @@ router.register(r'recon', ReconViewset)
 router.register(r'nmap', NmapViewset)
 
 urlpatterns = [
-    path('login', LoginView.as_view()),
-    path('logout', LogoutView.as_view()),
+    path(r'login', LoginView.as_view(), name='knox_login'),
+    path('logout', LogoutView.as_view(), name='knox_logout'),
     path('ping', PingView.as_view()),
     path('confirm', ConfirmAccountView.as_view()),
     path('reset', ResetPasswordView.as_view()),

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -10,6 +10,7 @@ django-trench==0.3.1
 django-phonenumber-field[phonenumbers]
 secure==0.3.0
 Pillow==9.4.0
+django-rest-knox==4.2.0
 
 pylint
 prospector

--- a/api/scripts/setup.sh
+++ b/api/scripts/setup.sh
@@ -31,6 +31,10 @@ install_postgresql () {
 ## SCRIPT ##
 ############
 
+# necessary know dependencies
+sudo apt-get install build-essential libssl-dev libffi-dev python3-dev python-dev
+
+
 install_postgresql
-# python3 manage.py makemigrations
+
 python3 manage.py migrate


### PR DESCRIPTION
# Description
Adding support for [django-rest-knox](https://james1345.github.io/django-rest-knox/) as it is quite easy to transition from default authentication system. If we want to, we can use something else later if there is really a need for it.

# Fixes

- fixes #46

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

- `/logout` route now expects `POST` method instead of `GET`

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added @vrn-sh/members to the reviewers, or specific members of the team
- [x] I have added the needed labels
- [x] I have tested this code
- [x] I have added / updated tests (unit / functionals / end-to-end / ...)
- [x] I have updated the README and other relevant documents (guides...)
