### PR TITLE
fix(api): values would not be correctly set in cache

### DIFF
--- a/api/api/models/__init__.py
+++ b/api/api/models/__init__.py
@@ -8,7 +8,7 @@ The following models are present here:
 """
 
 import uuid
-from logging import info, warn
+from logging import info, warning
 import os
 from typing import List, Optional
 
@@ -80,17 +80,17 @@ class Auth(AbstractUser):
         """sends account-confirmation email"""
 
         if '1' in (os.environ.get('TEST', '0'), os.environ.get('CI', '0')):
-            warn(f'Passing send_confirm_email() to {self.email}')
+            warning(f'Passing send_confirm_email() to {self.email}')
             return 1
 
-        tmp_token = uuid.uuid4()
+        tmp_token = uuid.uuid4().hex
         url = f'https://{os.environ["DOMAIN_NAME"]}/confirm?token={tmp_token}'
-        cache.set(f'{self.email};CONFIRM', tmp_token, CONFIRM_TOKEN_TIMEOUT_SECONDS)
+        cache.set(tmp_token, self.email, CONFIRM_TOKEN_TIMEOUT_SECONDS)
 
-        warn(f'Sending confirmation email to {self.email}')
+        warning(f'Sending confirmation email to {self.email}')
         return send_mail(
             f'Welcome {self.first_name} !',
-            f'Hello and welcome!\nPlease click on the following link to confirm your account: {url}',
+            f'Hello and welcome!\nPlease click on this link to confirm your account: {url}',
             os.environ['SENDGRID_SENDER'],
             [self.email],
             fail_silently=False,
@@ -103,14 +103,14 @@ class Auth(AbstractUser):
             info(f'Passing send_reset_password_email() to {self.email}')
             return 1
 
-        tmp_token = uuid.uuid4()
+        tmp_token = uuid.uuid4().hex
         url = f'https://{os.environ["DOMAIN_NAME"]}/reset?token={tmp_token}'
-        cache.set(f'{self.email};RESETPW', tmp_token, RESETPW_TOKEN_TIMEOUT_SECONDS)
+        cache.set(tmp_token, self.email, RESETPW_TOKEN_TIMEOUT_SECONDS)
 
-        info(f'Sending password-reset email to {self.email}')
+        warning(f'Sending password-reset email to {self.email}')
         return send_mail(
             f'{self.first_name}, reset your password',
-            f'Please click on the following link to reset your password: {url}',
+            f'Hello there\nPlease click on this link to reset your password: {url}',
             os.environ['SENDGRID_SENDER'],
             [self.email],
             fail_silently=False,
@@ -119,7 +119,6 @@ class Auth(AbstractUser):
     def save(self, *args, **kwargs) -> None:
         if self.is_enabled is False:
             self.send_confirm_email()
-            self.is_enabled = False
         return super().save(*args, **kwargs)
 
 

--- a/api/api/views/__init__.py
+++ b/api/api/views/__init__.py
@@ -51,10 +51,11 @@ class ResetPasswordView(APIView):
     @swagger_auto_schema(
         operation_description="sets new password",
         manual_parameters=[
-            openapi.Parameter(name="token",
+            openapi.Parameter(
+                "token",
+                "path",
                 required=True,
-                type="string",
-                in_="path",
+                type=openapi.TYPE_STRING,
                 description="account confirmation token",
             ),
         ],
@@ -77,9 +78,8 @@ class ResetPasswordView(APIView):
         new_pass: Optional[str] = request.data.get('password', None)
 
         user: Optional[Auth] = None
-        token_key: str = cache.get('token')
-        if token_key:
-            email = token_key.split(';')[0]
+        email: str = cache.get(token)
+        if email:
             user = Auth.objects.filter(email=email).first()
 
         if not user or not token or not new_pass:
@@ -166,7 +166,7 @@ class ConfirmAccountView(APIView):
             Requests a (new) confirmation email. Expects an email field.
         """
 
-        email = request.GET.get('email')
+        email = request.data.get('email')
         if email is None:
             return Response({
                 'error': 'no email provided',
@@ -188,10 +188,11 @@ class ConfirmAccountView(APIView):
     @swagger_auto_schema(
         operation_description="confirms account using a token and sets new password",
         manual_parameters=[
-            openapi.Parameter(name="token",
+            openapi.Parameter(
+                "token",
+                "path",
                 required=True,
-                type="string",
-                in_="path",
+                type=openapi.TYPE_STRING,
                 description="account confirmation token",
             ),
         ],
@@ -226,9 +227,9 @@ class ConfirmAccountView(APIView):
             }, status=HTTP_400_BAD_REQUEST)
 
         account: Optional[Auth] = None
-        token_key: str = cache.get('token')
-        if token_key:
-            email = token_key.split(';')[0]
+        email: str = cache.get(token)
+
+        if email:
             account = Auth.objects.filter(email=email).first()
 
         if account:


### PR DESCRIPTION
# Description
There were a couple of issues regarding the setting to cache of an account's email:

1. key & value would be interverted in `cache.set()` call (lol)
2. uuid type was saved as a `UUID` class, which made it annoying to retrieve from query param
3. documentation was not correct, regarding which settings to set. This has been fixed as well

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added @vrn-sh/members to the reviewers, or specific members of the team
- [x] I have added the needed labels
- [x] I have tested this code
- [x] I have added / updated tests (unit / functionals / end-to-end / ...)
- [x] I have updated the README and other relevant documents (guides...)