### PR TITLE
feat(web): adding 2 more dorks (Pastebin links & PHP path parameters)

### DIFF
--- a/web/src/assets/strings/en/dorks.json
+++ b/web/src/assets/strings/en/dorks.json
@@ -149,6 +149,16 @@
             "id": 30,
             "title": "Search in SHODAN",
             "path": "https://www.shodan.io/search?query={{DOMAIN}}"
+        }],
+        [{
+            "id": 31,
+            "title": "Pastebin leaks",
+            "path": "https://www.google.com/search?q=site:pastebin.com+\"{{DOMAIN}}\""
+        },
+        {
+            "id": 32,
+            "title": "PHP extensions with path parameters",
+            "path": "https://www.google.com/search?q=site:{{DOMAIN}}+ext:php+inurl:?"
         }]
     ]
 }


### PR DESCRIPTION
# Description

Just adds support for 2 more dorks i found while browsing twitter:
- search for a specific domain on pastebin
- search for fuzzable path parameters on PHP pages 

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Additional comments

Completely unrelated, but i found you can combine domains for a dork like so:
`(site:voron.djnn.sh | site:github.com) & "register"`

i dont think we support something like this, but it's kind of nifty tbh. i could create an issue for a bonus or something
