### PR TITLE
fix(api): docker setup for development

### DIFF
--- a/api/.env-dist
+++ b/api/.env-dist
@@ -1,8 +1,8 @@
 # database
 POSTGRES_DB=voron
-POSTGRES_USER=user_name
-POSTGRES_PASSWORD=very_secure_password
-POSTGRES_HOST=db
+POSTGRES_USER=YOUR_USER_NAME
+POSTGRES_PASSWORD=postgres          # OR a more secure password if running in production
+POSTGRES_HOST=localhost             # OR 'db' if you are using docker`
 POSTGRES_PORT=5432
 POSTGRES_DATA=/var/lib/postgresql/data/pgdata
 
@@ -10,20 +10,19 @@ POSTGRES_DATA=/var/lib/postgresql/data/pgdata
 NGINX_ENVSUBST_OUTPUT_DIR=/etc/nginx
 
 # object-storage
-MINIO_HOST=s3
-MINIO_ROOT_USER=somesecretaccesskey
-MINIO_ROOT_PASSWORD=somesecretsecretkey
+MINIO_HOST=YOUR_S3_ENDPOINT         # (or 's3:9000' if PRODUCTION != 1)
+MINIO_ROOT_USER=YOUR_SECRET_ACCESS_KEY
+MINIO_ROOT_PASSWORD=YOUR_SECRET_PASSWORD
 
 # api-layer
-DJANGO_SECRET_KEY=somesupersecretkey
-DOMAIN_NAME=voron.lan
-PRODUCTION=1
+DJANGO_SECRET_KEY=SOME_RANDOM_KEY   # will be regenerated at runtime if running on Docker
+DOMAIN_NAME=localhost:8080          # or your domain name (eg: example.com). If using docker-compose-dev.yml, use 'localhost:3000'
+PRODUCTION=0                        # or '1' if deployed in user-facing setup
+IN_CONTAINER=1                      # will automatically be set to '1' by entrypoint.sh
 
 # third-party
-SENDGRID_API_KEY=SG_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-SENDGRID_SENDER=something@email.com
-SENDGRID_RESET_TEMPLATE_ID=some_template_id
-SENDGRID_CONFIRM_TEMPLATE_ID=some_template_id
+SENDGRID_API_KEY=YOUR_SENGRID_KEY
+SENDGRID_SENDER=YOUR_SENGRID_SENDER
 
-# API linter stuff
+# API linter stuff (you don't actually need this to run the app, just some for linter)
 DJANGO_SETTINGS_MODULE='core.settings'

--- a/api/.env-dist
+++ b/api/.env-dist
@@ -3,7 +3,7 @@ POSTGRES_DB=voron
 POSTGRES_USER=YOUR_USER_NAME
 POSTGRES_PASSWORD=postgres          # OR a more secure password if running in production
 POSTGRES_HOST=localhost             # OR 'db' if you are using docker`
-POSTGRES_PORT=5432
+POSTGRES_PORT=5432                  # OR 5431 if running docker-compose-dev.yml
 POSTGRES_DATA=/var/lib/postgresql/data/pgdata
 
 # reverse-proxy layer

--- a/api/api/management/middlewares.py
+++ b/api/api/management/middlewares.py
@@ -1,10 +1,5 @@
 """
     middleware to set OWASP secure headers in any response from the API
-
-    04/05/2023: temporarily dropped support before investigation regarding
-    API calls which are sometimes unavailable with these headers
-
-    FIXME(djnn): investigate this when i have 5 minutes
 """
 
 
@@ -14,8 +9,7 @@ import secure
 
 def is_in_prod() -> bool:
     """check if unit tests are running"""
-    return os.environ.get('TEST', '0') != '1' and \
-            os.environ.get('PRODUCTION', '0') == '1'
+    return os.environ.get('PRODUCTION', '0') == '1'
 
 if is_in_prod():
     secure_headers = secure.Secure()

--- a/api/api/models/mission.py
+++ b/api/api/models/mission.py
@@ -113,7 +113,7 @@ class Mission(models.Model):
             self.recon = Recon.objects.create()
             self.bucket_name = uuid.uuid4().hex
 
-            if environ.get('PRODUCTION', '0') == '1':
+            if environ.get('IN_CONTAINER', '0') == '1':
                 S3Bucket().create_bucket(self.bucket_name)
 
         super().save(*args, **kwargs)

--- a/api/api/services/s3.py
+++ b/api/api/services/s3.py
@@ -9,6 +9,7 @@ from minio.versioningconfig import ENABLED
 
 class S3Bucket:
     def __init__(self) -> None:
+        # containers can be ran locally and dont need ssl
         self.client = Minio(
             os.environ["MINIO_HOST"],
             os.environ['MINIO_ROOT_USER'],

--- a/api/api/views/report.py
+++ b/api/api/views/report.py
@@ -49,14 +49,15 @@ class GenerateReportView(APIView):
 
     @swagger_auto_schema(
         operation_description="Get the mission report generated with the mission' data.",
-        manual_parameters=[openapi.Schema(
-            type=openapi.TYPE_OBJECT,
-            required=['mission'],
-            properties={
-                'mission': openapi.Schema(type=openapi.TYPE_INTEGER,
-                                          description="Id of mission"),
-            },
-        )],
+        manual_parameters=[
+            openapi.Parameter(
+                "mission",
+                "path",
+                required=True,
+                type=openapi.TYPE_INTEGER,
+                description="id of the mission"
+            )
+        ],
         responses={
             "302": openapi.Response(
                 description="Redirection to the minio storage of the pdf file.",

--- a/api/core/settings.py
+++ b/api/core/settings.py
@@ -99,12 +99,17 @@ TEMPLATES = [
 
 WSGI_APPLICATION = 'core.wsgi.application'
 
+
+def is_localhost(host: str) -> bool:
+    return 'localhost' in host or '127.0.0.1' in host
+
+
 DOMAIN_NAME = os.environ.get('DOMAIN_NAME', 'localhost:8080')
 
 SECRET_KEY = os.environ.get('DJANGO_SECRET_KEY', 'django-insecure-mdvq2h0e3!@5edgf)5c2qt@cin6m3(3n8f=5gi6qdy207oi-p)')
 DEBUG = os.environ.get('PRODUCTION', '0') != '1' # returns true if not in production
-ALLOWED_HOSTS = ['localhost' if 'localhost' in DOMAIN_NAME else DOMAIN_NAME]
-CORS_ALLOWED_ORIGIN = [["*" if 'localhost' in DOMAIN_NAME else DOMAIN_NAME]]
+ALLOWED_HOSTS = ['localhost' if is_localhost(DOMAIN_NAME) else DOMAIN_NAME]
+CORS_ALLOWED_ORIGIN = [["*" if is_localhost(DOMAIN_NAME) else DOMAIN_NAME]]
 CORS_ORIGIN_ALLOW_ALL = os.environ.get('PRODUCTION', '0') != '1' # returns true if not in production
 
 if os.environ.get('IN_CONTAINER', '0') == '1' or os.environ.get('PRODUCTION', '0') == '1':

--- a/api/core/settings.py
+++ b/api/core/settings.py
@@ -99,58 +99,19 @@ TEMPLATES = [
 
 WSGI_APPLICATION = 'core.wsgi.application'
 
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.postgresql',
-        'NAME': 'voron',
-        'USER': os.environ.get('USER'),
-        'PASSWORD': 'postgres',
-        'HOST': 'localhost',
-        'PORT': '',
-    }
-}
-SECRET_KEY = 'django-insecure-mdvq2h0e3!@5edgf)5c2qt@cin6m3(3n8f=5gi6qdy207oi-p)'
-DEBUG = True
-ALLOWED_HOSTS = ['*']
-CORS_ALLOWED_ORIGIN = [["*"]]
-CORS_ORIGIN_ALLOW_ALL = True
+DOMAIN_NAME = os.environ.get('DOMAIN_NAME', 'localhost:8080')
 
-# cache configuration
-CACHES = {
-    "default": {
-        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
-    }
-}
+SECRET_KEY = os.environ.get('DJANGO_SECRET_KEY', 'django-insecure-mdvq2h0e3!@5edgf)5c2qt@cin6m3(3n8f=5gi6qdy207oi-p)')
+DEBUG = os.environ.get('PRODUCTION', '0') != '1' # returns true if not in production
+ALLOWED_HOSTS = ['*' if 'localhost' in DOMAIN_NAME else DOMAIN_NAME]
+CORS_ALLOWED_ORIGIN = [["*" if 'localhost' in DOMAIN_NAME else DOMAIN_NAME]]
+CORS_ORIGIN_ALLOW_ALL = os.environ.get('PRODUCTION', '0') != '1' # returns true if not in production
 
-if os.environ.get('PRODUCTION', '0') == '1':
-
-    DATABASES = {
-        'default': {
-            'ENGINE': 'django.db.backends.postgresql',
-            'NAME': os.environ.get('POSTGRES_DB'),
-            'USER': os.environ.get('POSTGRES_USER'),
-            'PASSWORD': os.environ.get('POSTGRES_PASSWORD'),
-            'HOST': os.environ.get('POSTGRES_HOST'),
-            'PORT': os.environ.get('POSTGRES_PORT'),
-        }
-    }
-    SECRET_KEY = os.environ.get('DJANGO_SECRET_KEY')
-    DEBUG = False
-    ALLOWED_HOSTS = [os.environ["DOMAIN_NAME"]]
-    CORS_ALLOWED_ORIGIN_REGEXES = [os.environ.get("DOMAIN_NAME")]
-    CORS_ALLOWED_ORIGIN = [os.environ["DOMAIN_NAME"]]
-    CORS_ORIGIN_ALLOW_ALL = False
-    CORS_ALLOW_CREDENTIALS = False
-
-    # production always runs on a container
-    os.environ['IN_CONTAINER'] = '1'
-
-if os.environ.get('IN_CONTAINER', '0') == '1':
+if os.environ.get('IN_CONTAINER', '0') == '1' or os.environ.get('PRODUCTION', '0') == '1':
 
     # S3 configuration
     AWS_ACCESS_KEY_ID = os.environ['MINIO_ROOT_USER']
     AWS_SECRET_ACCESS_KEY = os.environ['MINIO_ROOT_PASSWORD']
-    AWS_STORAGE_BUCKET_NAME = "rootbucket"
     AWS_S3_ENDPOINT_URL = "s3:9000"
     AWS_DEFAULT_ACL = None
     AWS_QUERYSTRING_AUTH = True
@@ -165,8 +126,18 @@ if os.environ.get('IN_CONTAINER', '0') == '1':
         }
     }
 
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.postgresql',
+            'NAME': os.environ.get('POSTGRES_DB'),
+            'USER': os.environ.get('POSTGRES_USER'),
+            'PASSWORD': os.environ.get('POSTGRES_PASSWORD'),
+            'HOST': os.environ.get('POSTGRES_HOST'),
+            'PORT': os.environ.get('POSTGRES_PORT'),
+        }
+    }
 
-if os.environ.get('TEST') and os.environ.get('TEST')  == '1':
+elif os.environ.get('TEST') and os.environ.get('TEST')  == '1':
     DATABASES = {
         'default': {
             'ENGINE': 'django.db.backends.postgresql',
@@ -175,6 +146,13 @@ if os.environ.get('TEST') and os.environ.get('TEST')  == '1':
             'PASSWORD': 'postgres',
             'HOST': 'localhost',
             'PORT': '',
+        }
+    }
+
+    # cache configuration
+    CACHES = {
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
         }
     }
 
@@ -189,6 +167,34 @@ elif os.environ.get('CI') and os.environ.get('CI')  == '1':
             'PORT': '',
         }
     }
+
+    # cache configuration
+    CACHES = {
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        }
+    }
+
+else:
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.postgresql',
+            'NAME': 'voron',
+            'USER': os.environ.get('USER'),
+            'PASSWORD': 'postgres',
+            'HOST': 'localhost',
+            'PORT': '',
+        }
+    }
+
+    # cache configuration
+    CACHES = {
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        }
+    }
+
+
 
 # Password validation
 # https://docs.djangoproject.com/en/4.1/ref/settings/#auth-password-validators

--- a/api/core/settings.py
+++ b/api/core/settings.py
@@ -103,7 +103,7 @@ DOMAIN_NAME = os.environ.get('DOMAIN_NAME', 'localhost:8080')
 
 SECRET_KEY = os.environ.get('DJANGO_SECRET_KEY', 'django-insecure-mdvq2h0e3!@5edgf)5c2qt@cin6m3(3n8f=5gi6qdy207oi-p)')
 DEBUG = os.environ.get('PRODUCTION', '0') != '1' # returns true if not in production
-ALLOWED_HOSTS = ['*' if 'localhost' in DOMAIN_NAME else DOMAIN_NAME]
+ALLOWED_HOSTS = ['localhost' if 'localhost' in DOMAIN_NAME else DOMAIN_NAME]
 CORS_ALLOWED_ORIGIN = [["*" if 'localhost' in DOMAIN_NAME else DOMAIN_NAME]]
 CORS_ORIGIN_ALLOW_ALL = os.environ.get('PRODUCTION', '0') != '1' # returns true if not in production
 

--- a/api/core/urls.py
+++ b/api/core/urls.py
@@ -20,7 +20,7 @@ from api.views.viewsets.mission import MissionViewset, NmapViewset, ReconViewset
 SchemaView = get_schema_view(
    openapi.Info(
       title="voron API",
-      default_version='0.1.0',
+      default_version='0.1.1',
       description="API storing and managing notes, users, and stuff",
       terms_of_service="https://github.com/vrn-sh/erp/blob/current/LICENSE",
       contact=openapi.Contact(email="voron@djnn.sh"),

--- a/api/scripts/entrypoint.sh
+++ b/api/scripts/entrypoint.sh
@@ -39,8 +39,9 @@ find / -name '*.pyc' -delete 2>/dev/null
 DJANGO_SECRET_KEY=$(generate_random_string)
 export DJANGO_SECRET_KEY
 
-PRODUCTION=1
-export PRODUCTION
+# force loading of in-container for settings.py
+IN_CONTAINER=1
+export IN_CONTAINER
 
 # wait for the database to boot up
 wait_for_it

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,24 +1,6 @@
 version: '3.9'
 
 services:
-  nginx:
-    image: nginx:latest
-    ports:
-      - "127.0.0.1:8080:80"
-    env_file:
-      - api/.env
-    volumes:
-      - ./services/nginx/nginx.conf:/etc/nginx/templates/nginx.conf.template:ro
-      - ./volumes/nginx/logs:/var/log/nginx:delegated
-    networks:
-      - api-layer
-      - web-layer
-      - s3-layer
-    depends_on:
-      - api
-      - web
-      - s3
-
   db:
     image: postgres:latest
     ports:

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -4,7 +4,7 @@ services:
   db:
     image: postgres:latest
     ports:
-      - "127.0.0.1:5432:5432"
+      - "127.0.0.1:5431:5432"
     env_file:
       - ./api/.env
     environment:


### PR DESCRIPTION
# Description
Fixes `docker` support for front-end dev team by doing a few things:
- back-end: `PRODUCTION` env value is now split into `PRODUCTION` for what is NEEDED for Prod (eg: SSL support, improved middlewares, restrict swagger access), & `IN_CONTAINER`, which manages integration with other containers
- back-end: re-enabling Secure headers for back-end (only for production now!)
- build: add a `docker-compose-dev.yml` that runs the whole infra WITHOUT `nginx`, so that requests are not automatically upgraded to HTTPS, etc...
- back-end: refactored the way `settings.py` pulls up the infra to avoid code repetition



# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes
New `.env` value for back-end. Please check `api/.env-dist` for more information!!

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added @vrn-sh/members to the reviewers, or specific members of the team
- [x] I have added the needed labels
- [x] I have tested this code
- [x] I have added / updated tests (unit / functionals / end-to-end / ...)
- [x] I have updated the README and other relevant documents (guides...)

# Additional comments
Using the following command, you can now access the OpenAPI documentation from docker:

```bash
docker compose -f docker-compose-dev.yml up
```

