### PR TITLE
fix(api): return only missions assigned to a specific pentester

### DIFF
--- a/api/api/views/viewsets/mission.py
+++ b/api/api/views/viewsets/mission.py
@@ -448,6 +448,14 @@ class MissionViewset(viewsets.ModelViewSet):  # pylint: disable=too-many-ancesto
         request.data['last_updated_by'] = request.user.id
         return super().create(request, *args, **kwargs)
 
+    def list(self, request, *args, **kwargs):
+        if request.user.role == 'manager':
+            return super().list(request, *args, **kwargs)
+
+        missions = Mission.objects.filter(team__members__auth__id=request.user.id)
+        serializer = self.get_serializer(missions, many=True)
+        return Response(serializer.data)
+
     def update(self, request, *args, **kwargs):
         if "created_by" in request.data:
             request.data.pop("created_by")


### PR DESCRIPTION
# Description

Allow pentesters to access only their missions

# Fixes

Specify which issue this PR targets, like so:

- fix #205 

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it.

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added @vrn-sh/members to the reviewers, or specific members of the team
- [x] I have added the needed labels
- [x] I have tested this code
- [ ] I have added / updated tests (unit / functionals / end-to-end / ...)
- [ ] I have updated the README and other relevant documents (guides...)

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it.
