### PR TITLE
fix(build): reaching `s3` service from docker-compose dev setup

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -9,21 +9,9 @@ services:
       - ./api/.env
     environment:
       - PGDATA=/var/lib/postgresql/data/pgdata
-    networks:
-      - db-layer
     volumes:
       - ./volumes/postgres:/var/lib/postgresql/data:delegated
-
-  # wapp-api:
-  #   environment:
-  #     IN_CONTAINER: 1
-  #   build:
-  #     context: ./services/wapp-api/.
-  #   ports:
-  #     - "127.0.0.1:4000:4000"
-  #   networks:
-  #     - api-layer
-
+    network_mode: host
 
   api:
     env_file:
@@ -34,10 +22,7 @@ services:
       - "127.0.0.1:8000:8000"
     depends_on:
       - db
-    networks:
-      - api-layer
-      - db-layer
-      - s3-layer
+    network_mode: host
 
   memcached:
    image: memcached:1.6
@@ -46,10 +31,9 @@ services:
    entrypoint:
     - memcached
     - -m 64
-   networks:
-    - api-layer
    depends_on:
      - api
+   network_mode: host
 
   web:
     build:
@@ -63,12 +47,11 @@ services:
       - ./web/.env
     depends_on:
       - api
-    networks:
-      - web-layer
+    network_mode: host
 
   s3:
     image: quay.io/minio/minio:RELEASE.2023-06-29T05-12-28Z
-    command: server --console-address ":9001" /data
+    command: server --console-address ":9001" --address ":9000" /data
     ports:
       - "127.0.0.1:9000:9000"
       - "127.0.0.1:9001:9001"
@@ -76,12 +59,5 @@ services:
       - ./api/.env
     volumes:
       - ./volumes/s3:/data:delegated
-    networks:
-      - s3-layer
-      - api-layer
+    network_mode: host
 
-networks:
-  db-layer:
-  api-layer:
-  web-layer:
-  s3-layer:


### PR DESCRIPTION
# Description

* added `network_mode: host` to reach all services from localhost: - https://docs.docker.com/compose/compose-file/compose-file-v3/#network_mode - https://stackoverflow.com/a/48806927



# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please note: you will have to point your services to `localhost` in `api/.env` instead of docker service names for local docker-compose-dev.yml

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added @vrn-sh/members to the reviewers, or specific members of the team
- [x] I have added the needed labels
- [x] I have tested this code
- [ ] I have added / updated tests (unit / functionals / end-to-end / ...)
- [ ] I have updated the README and other relevant documents (guides...)
